### PR TITLE
Fix child id for player dialogue text

### DIFF
--- a/src/main/java/com/npcdialoglog/NpcDialogLog.java
+++ b/src/main/java/com/npcdialoglog/NpcDialogLog.java
@@ -51,7 +51,7 @@ public class NpcDialogLog extends Plugin
 	private void checkWidgetDialogs()
 	{
 		final String npcDialogText = getWidgetTextSafely();
-		final String playerDialogText = getWidgetTextSafely(WidgetID.DIALOG_PLAYER_GROUP_ID, 4);
+		final String playerDialogText = getWidgetTextSafely(WidgetID.DIALOG_PLAYER_GROUP_ID, WidgetInfo.DIALOG_NPC_TEXT.getChildId());//using the npc text child id as they seem to be the same
 
 		// For when the NPC has dialog
 		if (npcDialogText != null && !lastNPCText.equals(npcDialogText))


### PR DESCRIPTION
The child id for the player text changed in the last update. 
Changed to use the NPC dialog text constant so it wont break in the future.
This closes #6 